### PR TITLE
LexMMIXAL.cxx: overflow issue has been fixed

### DIFF
--- a/lexers/LexMMIXAL.cxx
+++ b/lexers/LexMMIXAL.cxx
@@ -102,9 +102,7 @@ static void ColouriseMMIXALDoc(Sci_PositionU startPos, Sci_Position length, int 
 				char s[100];
 				sc.GetCurrent(s, sizeof(s));
 				if (*s == ':') {	// ignore base prefix for match
-					for (size_t i = 0; i != sizeof(s); ++i) {
-						*(s+i) = *(s+i+1);
-					}
+					memmove(s + 1, s, sizeof(s) - 1);
 				}
 				if (special_register.InList(s)) {
 					sc.ChangeState(SCE_MMIXAL_REGISTER);

--- a/lexers/LexMMIXAL.cxx
+++ b/lexers/LexMMIXAL.cxx
@@ -102,7 +102,7 @@ static void ColouriseMMIXALDoc(Sci_PositionU startPos, Sci_Position length, int 
 				char s[100];
 				sc.GetCurrent(s, sizeof(s));
 				if (*s == ':') {	// ignore base prefix for match
-					memmove(s + 1, s, sizeof(s) - 1);
+					memmove(s, s + 1, sizeof(s) - 1);
 				}
 				if (special_register.InList(s)) {
 					sc.ChangeState(SCE_MMIXAL_REGISTER);


### PR DESCRIPTION
From GCC:
`In function 'void ColouriseMMIXALDoc(Sci_PositionU, Sci_Position, int, WordList**, Accessor&)':
cc1plus.exe: warning: 'void* __builtin_memmove(void*, const void*, unsigned int)' reading 100 bytes from a region of size 99 [-Wstringop-overflow=]`

overflow has been fixed (wrong stop condition in loop) and loop has been replaced by memmove